### PR TITLE
Fix positioning

### DIFF
--- a/src/components/lib/positioning.js
+++ b/src/components/lib/positioning.js
@@ -57,13 +57,13 @@ function getPosition (w, e, config) {
     }
   }
 
-  let left = Math.max(padding, e.pageX - (width / 2))
+  let left = Math.max(padding, e.clientX - (width / 2))
 
   if ((left + width) > pageWidth) {
     left = (pageWidth - width) - padding
   }
 
-  let top = Math.max(padding, e.pageY - (height / 2))
+  let top = Math.max(padding, e.clientY - (height / 2))
 
   const willExceedViewableArea = (top + height) > viewportHeight
   if (willExceedViewableArea) {


### PR DESCRIPTION
Hi!

Thanks for this handy date picker.

Any reason why pageY/X is used instead of clientY/X for calculating the popover position? Using pageY/X causes popover to be pushed to viewport max bounds if viewport is scrolled sufficiently instead of being placed close to input element.

Adding some extra bottom and top padding to the documentation examples demonstrates the issue:

pageY, notice the gap:

![Screenshot 2023-04-18 at 15 09 01](https://user-images.githubusercontent.com/1001505/232789472-01560ad7-5555-4504-9888-be60fcd18601.png)

Simply changing to clientY fixes this:

![Screenshot 2023-04-18 at 15 09 42](https://user-images.githubusercontent.com/1001505/232790081-78566049-9d64-4af1-ad70-746eb4e1ade2.png)
